### PR TITLE
Fix native interop lifetime and validation bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,10 @@ Thumbs.db
 # Temporary files
 *.tmp
 *.temp
-src/native/liboqs.so.0.13.0
 
 bin/
 obj/
-src/native/runtimes/win-arm64/native/oqs.dll
+/src/native/runtimes/*/native/*.dll
+/src/native/runtimes/*/native/*.so
+/src/native/runtimes/*/native/*.dylib
+/src/native/runtimes/*/native/*.pdb

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ git submodule update
    - Configure and build liboqs as a shared library
    - Copy the resulting DLL/so/dylib to the appropriate directories
    - Enable all common quantum-resistant algorithms (ML-KEM, ML-DSA, SLH-DSA, Kyber, Falcon, FrodoKEM, BIKE, HQC, NTRU, SNOVA, MQOM, etc.)
+   - On Windows and macOS, build MQOM from its memory-optimized implementation (`-DOQS_MEMOPT_BUILD=ON`), see [Platform Support](#platform-support)
 
 2. **Build the .NET libraries:**
 
@@ -256,7 +257,7 @@ git submodule update
 
 ### Submodule Management
 
-This project uses [liboqs 0.16.0-rc1](https://github.com/Open-Quantum-Safe/liboqs/releases/tag/0.16.0-rc1) as a git submodule.
+This project uses [liboqs 0.16.0](https://github.com/Open-Quantum-Safe/liboqs/releases/tag/0.16.0) as a git submodule.
 
 **Update to latest liboqs version:**
 ```bash
@@ -292,9 +293,9 @@ LibOQS.NET supports the following platforms out of the box with no additional se
 - **macOS ARM64**
 
 > [!NOTE]
-> **Platform Limitations**: 
-> - **Windows**: `SLH-DSA` (Pure variants) and `MQOM` are currently disabled due to known bugs in `liboqs` 0.16.0-rc1 that cause a stack overflow during signing on Windows. `BIKE` is also disabled on Windows.
-> - **macOS**: `MQOM` is disabled because its `short` variants overflow the stack during signing in `liboqs` 0.16.0-rc1.
+> **Platform Limitations**:
+> - **Windows**: `SLH-DSA` (Pure variants) is disabled because of a known bug in `liboqs` that causes a stack overflow during signing on Windows. `BIKE` is unavailable because `liboqs` itself does not support it on Windows.
+> - **MQOM** is enabled on all platforms. On Windows and macOS it is built from the memory-optimized implementation introduced in `liboqs` 0.16.0 (`OQS_MEMOPT_BUILD`), because the default implementation needs more than 1 MB of stack to sign and overflows the stack of non-main threads. Linux keeps the default (AVX2-accelerated on x64) implementation, where the larger default thread stack is sufficient.
 
 The NuGet packages include all necessary native libraries for these platforms.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ dotnet add package LibOQS.NET
 ```csharp
 using LibOQS.NET;
 
-// LibOQS initializes automatically - no manual Initialize() call needed
+// LibOQS initializes on first use - no manual Initialize() call needed
 try
 {
     // Key Encapsulation Mechanism example
@@ -64,7 +64,8 @@ try
 }
 finally
 {
-    // Optional cleanup - called automatically at app shutdown
+    // Optional: releases OQS_destroy() state. Only safe once every instance above is disposed,
+    // which the `using` declarations guarantee by the time we get here.
     LibOqs.Cleanup();
 }
 ```
@@ -161,19 +162,26 @@ if (KemAlgorithm.MlKem512.IsEnabled())
 
 ## Memory Management
 
-The library properly manages native resources:
+Native resources are held behind a `SafeHandle`:
 
-- **Automatic initialization**: LibOQS initializes automatically via static constructor
-- **Automatic cleanup**: Use `using` statements with `KemInstance` and `SigInstance`
-- **Optional manual cleanup**: Call `LibOqs.Cleanup()` when completely done with the library
+- **Automatic initialization**: the native library is initialized on demand by the first call that needs it; you never have to call `LibOqs.Initialize()` yourself, though it is public and idempotent
+- **Deterministic release**: wrap `KemInstance` and `SigInstance` in `using` declarations. `Dispose()` is idempotent and safe to call concurrently
+- **Backstop**: an instance that is never disposed is released by the handle's critical finalizer, so the native allocation is not leaked
+- **Optional manual cleanup**: `LibOqs.Cleanup()` calls `OQS_destroy()`. Only call it once every instance has been disposed — liboqs behaviour is undefined if instances outlive it. It is *not* invoked automatically at process exit
+
+> [!IMPORTANT]
+> Key material is returned as ordinary managed `byte[]`. The garbage collector may move or copy
+> those arrays, and nothing zeroes them when they fall out of scope, so the library cannot
+> guarantee that secret keys or shared secrets are erased from process memory. If that matters for
+> your threat model, clear the arrays yourself when you are done with them (for example with
+> `CryptographicOperations.ZeroMemory`) and consider pinning them for their lifetime.
 
 ## Thread Safety
 
-The native liboqs library is generally thread-safe for read operations but may not be thread-safe for initialization. It's recommended to:
-
-- Use separate instances of `KemInstance` and `SigInstance` per thread
-- The automatic initialization is thread-safe
-- Call `LibOqs.Cleanup()` once at application shutdown if needed
+- The on-demand initialization is thread-safe
+- `Dispose()` is thread-safe and idempotent on both `KemInstance` and `SigInstance`, and will not release the native object while another thread still has a call in flight
+- Prefer a separate `KemInstance` / `SigInstance` per thread. The instances hold no mutable managed state, but sharing one across threads is not covered by the test suite
+- Call `LibOqs.Cleanup()` once at application shutdown, if at all, and only after every instance has been disposed
 
 ## Error Handling
 

--- a/build-dotnet-liboqs-macos.sh
+++ b/build-dotnet-liboqs-macos.sh
@@ -29,7 +29,10 @@ cd "$BUILD_DIR"
 
 echo "Configuring CMake for shared library build..."
 
-# Configure with shared library options
+# Configure with shared library options.
+# OQS_MEMOPT_BUILD makes MQOM use its memory-optimized implementation. The default MQOM
+# implementation needs more than 1 MB of stack to sign, which overflows the stack of
+# non-main threads (e.g. .NET thread pool threads); the memory-optimized one fits in 512 KB.
 cmake .. \
     -DCMAKE_BUILD_TYPE="$CONFIGURATION" \
     -DBUILD_SHARED_LIBS=ON \
@@ -39,6 +42,7 @@ cmake .. \
     -DOQS_BUILD_ONLY_LIB=ON \
     -DOQS_DIST_BUILD=YES \
     -DOQS_PERMIT_UNSUPPORTED_ARCHITECTURE=ON \
+    -DOQS_MEMOPT_BUILD=ON \
     -DOQS_ENABLE_KEM_ML_KEM=ON \
     -DOQS_ENABLE_KEM_KYBER=ON \
     -DOQS_ENABLE_KEM_FRODOKEM=ON \
@@ -53,7 +57,7 @@ cmake .. \
     -DOQS_ENABLE_SIG_MAYO=ON \
     -DOQS_ENABLE_SIG_CROSS=ON \
     -DOQS_ENABLE_SIG_UOV=ON \
-    -DOQS_ENABLE_SIG_MQOM=OFF \
+    -DOQS_ENABLE_SIG_MQOM=ON \
     -DOQS_ENABLE_SIG_SNOVA=ON
 
 echo "Building liboqs..."

--- a/build-dotnet-liboqs.ps1
+++ b/build-dotnet-liboqs.ps1
@@ -36,6 +36,9 @@ try {
             "-DOQS_BUILD_ONLY_LIB=ON"
             "-DOQS_DIST_BUILD=YES"
             "-DOQS_PERMIT_UNSUPPORTED_ARCHITECTURE=ON"
+            # MQOM selects its memory-optimized implementation; the default one needs
+            # more than 1 MB of stack to sign, which overflows the default thread stack.
+            "-DOQS_MEMOPT_BUILD=ON"
         )
         
         # Add platform-specific configuration for ARM64
@@ -58,7 +61,7 @@ try {
             "-DOQS_ENABLE_SIG_SLH_DSA=OFF"
             "-DOQS_ENABLE_SIG_SNOVA=ON"
             "-DOQS_ENABLE_SIG_FALCON=ON"
-            "-DOQS_ENABLE_SIG_MQOM=OFF"
+            "-DOQS_ENABLE_SIG_MQOM=ON"
             "-DOQS_ENABLE_SIG_MAYO=ON"
             "-DOQS_ENABLE_SIG_CROSS=ON"
             "-DOQS_ENABLE_SIG_UOV=ON"

--- a/samples/Examples/Program.cs
+++ b/samples/Examples/Program.cs
@@ -309,6 +309,9 @@ public static class LibOqsDemo
                 _ when sigAlg.ToString().Contains("OvIs") || sigAlg.ToString().Contains("OvIp") => "Level 1",
                 _ when sigAlg.ToString().Contains("OvIii") => "Level 3",
                 _ when sigAlg.ToString().Contains("OvV") => "Level 5",
+                _ when sigAlg.ToString().Contains("Cat1") => "Level 1",
+                _ when sigAlg.ToString().Contains("Cat3") => "Level 3",
+                _ when sigAlg.ToString().Contains("Cat5") => "Level 5",
                 _ => "Various"
             };
 

--- a/src/LibOQS.NET.Native/Common.cs
+++ b/src/LibOQS.NET.Native/Common.cs
@@ -47,10 +47,16 @@ public static class Common
     public static extern IntPtr OQS_MEM_malloc(UIntPtr size);
 
     /// <summary>
-    /// Free memory
+    /// Free memory allocated by liboqs, without zeroing it first
     /// </summary>
     [DllImport(LibraryName, CallingConvention = CallingConvention.Cdecl)]
-    public static extern void OQS_MEM_free(IntPtr ptr);
+    public static extern void OQS_MEM_insecure_free(IntPtr ptr);
+
+    /// <summary>
+    /// Free memory allocated by liboqs, without zeroing it first
+    /// </summary>
+    [Obsolete("liboqs exports no OQS_MEM_free symbol, so calling this always threw EntryPointNotFoundException. Use OQS_MEM_insecure_free instead.")]
+    public static void OQS_MEM_free(IntPtr ptr) => OQS_MEM_insecure_free(ptr);
 
     /// <summary>
     /// Secure free memory

--- a/src/LibOQS.NET.Native/Handles.cs
+++ b/src/LibOQS.NET.Native/Handles.cs
@@ -1,0 +1,53 @@
+using System.Runtime.InteropServices;
+
+namespace LibOQS.NET.Native;
+
+/// <summary>
+/// Safe handle for an <c>OQS_KEM</c> allocated by <see cref="Kem.OQS_KEM_new_handle"/>.
+/// </summary>
+/// <remarks>
+/// Passing this handle to a P/Invoke keeps it alive and reference-counted for the duration of the
+/// call, so the underlying <c>OQS_KEM</c> cannot be released while native code is still using it.
+/// Releasing is idempotent and thread-safe, which rules out double frees.
+/// </remarks>
+public sealed class OqsKemHandle : SafeHandle
+{
+    // Required by the interop marshaller, which instantiates the handle when a
+    // P/Invoke declared with this return type returns.
+    private OqsKemHandle() : base(IntPtr.Zero, ownsHandle: true) { }
+
+    /// <inheritdoc />
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    /// <inheritdoc />
+    protected override bool ReleaseHandle()
+    {
+        Kem.OQS_KEM_free(handle);
+        return true;
+    }
+}
+
+/// <summary>
+/// Safe handle for an <c>OQS_SIG</c> allocated by <see cref="Sig.OQS_SIG_new_handle"/>.
+/// </summary>
+/// <remarks>
+/// Passing this handle to a P/Invoke keeps it alive and reference-counted for the duration of the
+/// call, so the underlying <c>OQS_SIG</c> cannot be released while native code is still using it.
+/// Releasing is idempotent and thread-safe, which rules out double frees.
+/// </remarks>
+public sealed class OqsSigHandle : SafeHandle
+{
+    // Required by the interop marshaller, which instantiates the handle when a
+    // P/Invoke declared with this return type returns.
+    private OqsSigHandle() : base(IntPtr.Zero, ownsHandle: true) { }
+
+    /// <inheritdoc />
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    /// <inheritdoc />
+    protected override bool ReleaseHandle()
+    {
+        Sig.OQS_SIG_free(handle);
+        return true;
+    }
+}

--- a/src/LibOQS.NET.Native/Kem.cs
+++ b/src/LibOQS.NET.Native/Kem.cs
@@ -72,6 +72,47 @@ public static class Kem
     [DllImport(Common.LibraryName, CallingConvention = CallingConvention.Cdecl)]
     public static extern Common.OqsStatus OQS_KEM_decaps(IntPtr kem, IntPtr shared_secret, IntPtr ciphertext, IntPtr secret_key);
 
+    // --- Safe-handle overloads -------------------------------------------------------------
+    // These target the same native entry points as the IntPtr declarations above. Prefer them:
+    // the marshaller reference-counts the handle across the call, so the OQS_KEM cannot be freed
+    // while native code is still reading it, and releasing it is idempotent and thread-safe.
+
+    /// <summary>
+    /// Get a KEM by name, as a safe handle
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_KEM_new", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    public static extern OqsKemHandle OQS_KEM_new_handle([MarshalAs(UnmanagedType.LPStr)] string method_name);
+
+    /// <summary>
+    /// Generate a keypair
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_KEM_keypair", CallingConvention = CallingConvention.Cdecl)]
+    public static extern Common.OqsStatus OQS_KEM_keypair(OqsKemHandle kem, IntPtr public_key, IntPtr secret_key);
+
+    /// <summary>
+    /// Generate a keypair with a seed (derandomized)
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_KEM_keypair_derand", CallingConvention = CallingConvention.Cdecl)]
+    public static extern Common.OqsStatus OQS_KEM_keypair_derand(OqsKemHandle kem, IntPtr public_key, IntPtr secret_key, IntPtr seed);
+
+    /// <summary>
+    /// Encapsulate
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_KEM_encaps", CallingConvention = CallingConvention.Cdecl)]
+    public static extern Common.OqsStatus OQS_KEM_encaps(OqsKemHandle kem, IntPtr ciphertext, IntPtr shared_secret, IntPtr public_key);
+
+    /// <summary>
+    /// Encapsulate with a seed (derandomized)
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_KEM_encaps_derand", CallingConvention = CallingConvention.Cdecl)]
+    public static extern Common.OqsStatus OQS_KEM_encaps_derand(OqsKemHandle kem, IntPtr ciphertext, IntPtr shared_secret, IntPtr public_key, IntPtr seed);
+
+    /// <summary>
+    /// Decapsulate
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_KEM_decaps", CallingConvention = CallingConvention.Cdecl)]
+    public static extern Common.OqsStatus OQS_KEM_decaps(OqsKemHandle kem, IntPtr shared_secret, IntPtr ciphertext, IntPtr secret_key);
+
     /// <summary>
     /// Check if a KEM algorithm is enabled
     /// </summary>

--- a/src/LibOQS.NET.Native/LibOQS.NET.Native.csproj
+++ b/src/LibOQS.NET.Native/LibOQS.NET.Native.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LibOQS.NET.Native</PackageId>
-    <PackageVersion>0.4.0-rc1</PackageVersion>
+    <PackageVersion>0.4.0</PackageVersion>
     <Authors>filipw</Authors>
     <Description>Native P/Invoke bindings for liboqs - a C library for quantum-resistant cryptographic algorithms</Description>
     <PackageProjectUrl>https://github.com/filipw/maybe-liboqs-dotnet</PackageProjectUrl>

--- a/src/LibOQS.NET.Native/Sig.cs
+++ b/src/LibOQS.NET.Native/Sig.cs
@@ -75,10 +75,56 @@ public static class Sig
     public static extern Common.OqsStatus OQS_SIG_verify_with_ctx_str(IntPtr sig, IntPtr message, UIntPtr message_len,
         IntPtr signature, UIntPtr signature_len, IntPtr ctx_str, UIntPtr ctx_str_len, IntPtr public_key);
 
+    // --- Safe-handle overloads -------------------------------------------------------------
+    // These target the same native entry points as the IntPtr declarations above. Prefer them:
+    // the marshaller reference-counts the handle across the call, so the OQS_SIG cannot be freed
+    // while native code is still reading it, and releasing it is idempotent and thread-safe.
+
+    /// <summary>
+    /// Get a signature algorithm by name, as a safe handle
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_SIG_new", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    public static extern OqsSigHandle OQS_SIG_new_handle([MarshalAs(UnmanagedType.LPStr)] string method_name);
+
+    /// <summary>
+    /// Generate a keypair
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_SIG_keypair", CallingConvention = CallingConvention.Cdecl)]
+    public static extern Common.OqsStatus OQS_SIG_keypair(OqsSigHandle sig, IntPtr public_key, IntPtr secret_key);
+
+    /// <summary>
+    /// Sign a message
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_SIG_sign", CallingConvention = CallingConvention.Cdecl)]
+    public static extern Common.OqsStatus OQS_SIG_sign(OqsSigHandle sig, IntPtr signature, ref UIntPtr signature_len,
+        IntPtr message, UIntPtr message_len, IntPtr secret_key);
+
+    /// <summary>
+    /// Sign a message with a context string
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_SIG_sign_with_ctx_str", CallingConvention = CallingConvention.Cdecl)]
+    public static extern Common.OqsStatus OQS_SIG_sign_with_ctx_str(OqsSigHandle sig, IntPtr signature, ref UIntPtr signature_len,
+        IntPtr message, UIntPtr message_len, IntPtr ctx_str, UIntPtr ctx_str_len, IntPtr secret_key);
+
+    /// <summary>
+    /// Verify a signature
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_SIG_verify", CallingConvention = CallingConvention.Cdecl)]
+    public static extern Common.OqsStatus OQS_SIG_verify(OqsSigHandle sig, IntPtr message, UIntPtr message_len,
+        IntPtr signature, UIntPtr signature_len, IntPtr public_key);
+
+    /// <summary>
+    /// Verify a signature with a context string
+    /// </summary>
+    [DllImport(Common.LibraryName, EntryPoint = "OQS_SIG_verify_with_ctx_str", CallingConvention = CallingConvention.Cdecl)]
+    public static extern Common.OqsStatus OQS_SIG_verify_with_ctx_str(OqsSigHandle sig, IntPtr message, UIntPtr message_len,
+        IntPtr signature, UIntPtr signature_len, IntPtr ctx_str, UIntPtr ctx_str_len, IntPtr public_key);
+
     /// <summary>
     /// Check if a signature algorithm supports context strings
     /// </summary>
     [DllImport(Common.LibraryName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+    [return: MarshalAs(UnmanagedType.U1)]
     public static extern bool OQS_SIG_supports_ctx_str([MarshalAs(UnmanagedType.LPStr)] string method_name);
 
     /// <summary>

--- a/src/LibOQS.NET.Tests/InteropSafetyTests.cs
+++ b/src/LibOQS.NET.Tests/InteropSafetyTests.cs
@@ -1,0 +1,174 @@
+using LibOQS.NET;
+using Xunit;
+
+namespace LibOQS.NET.Tests;
+
+/// <summary>
+/// Regression tests for native interop lifetime and argument-validation defects.
+/// </summary>
+public class InteropSafetyTests
+{
+    // Before the SafeHandle migration, Dispose() checked and cleared its state without
+    // synchronisation, so two threads could both reach OQS_KEM_free with the same pointer.
+    // That aborted the process with a libmalloc "pointer being freed was not allocated" report.
+    [Fact]
+    public void ConcurrentDispose_ShouldNotDoubleFree()
+    {
+        for (var round = 0; round < 250; round++)
+        {
+            var kem = new KemInstance(KemAlgorithm.MlKem512);
+            var sig = new SigInstance(SigAlgorithm.MlDsa44);
+
+            using var gate = new ManualResetEventSlim(false);
+            var threads = new[]
+            {
+                new Thread(() => { gate.Wait(); kem.Dispose(); }),
+                new Thread(() => { gate.Wait(); kem.Dispose(); }),
+                new Thread(() => { gate.Wait(); sig.Dispose(); }),
+                new Thread(() => { gate.Wait(); sig.Dispose(); }),
+            };
+
+            foreach (var t in threads)
+            {
+                t.Start();
+            }
+
+            gate.Set();
+
+            foreach (var t in threads)
+            {
+                Assert.True(t.Join(TimeSpan.FromSeconds(30)), "Dispose thread did not finish");
+            }
+        }
+    }
+
+    // The safe handle is reference-counted across the P/Invoke, so a Dispose() arriving from
+    // another thread while a native call is in flight must not free the OQS_KEM underneath it.
+    [Fact]
+    public void DisposeDuringNativeCall_ShouldNotUseAfterFree()
+    {
+        for (var round = 0; round < 50; round++)
+        {
+            var kem = new KemInstance(KemAlgorithm.MlKem768);
+            var disposer = new Thread(() => kem.Dispose());
+            disposer.Start();
+
+            try
+            {
+                var (publicKey, _) = kem.GenerateKeypair();
+                Assert.Equal(kem.PublicKeyLength, publicKey.Length);
+            }
+            catch (ObjectDisposedException)
+            {
+                // Disposed before the call started: rejected cleanly, which is also correct.
+            }
+
+            Assert.True(disposer.Join(TimeSpan.FromSeconds(30)), "Dispose thread did not finish");
+        }
+    }
+
+    // Instances that go out of scope without Dispose() are released by the handle's critical
+    // finalizer. Exercise that under GC pressure to catch premature or double release.
+    [Fact]
+    public void UndisposedInstances_ShouldBeReleasedByFinalizer()
+    {
+        static int UseUnrootedKem() =>
+            new KemInstance(KemAlgorithm.MlKem512).GenerateKeypair().PublicKey.Length;
+
+        static int UseUnrootedSig() =>
+            new SigInstance(SigAlgorithm.MlDsa44).GenerateKeypair().PublicKey.Length;
+
+        for (var round = 0; round < 100; round++)
+        {
+            Assert.True(UseUnrootedKem() > 0);
+            Assert.True(UseUnrootedSig() > 0);
+
+            if (round % 10 == 0)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            }
+        }
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+    }
+
+    // A zero-length seed used to slip past the `seed.Length != SeedLength` guard (0 != 0 is false)
+    // and take the derandomized path with a NULL seed pointer, surfacing as a misleading
+    // "Failed to encapsulate". It must be rejected up front instead.
+    [SkippableFact]
+    public void ZeroLengthSeed_OnAlgorithmWithoutDerandomization_ShouldThrowArgumentException()
+    {
+        Skip.If(!KemAlgorithm.ClassicMcEliece348864.IsEnabled(),
+            "Classic-McEliece-348864 is not enabled in this build.");
+
+        using var kem = new KemInstance(KemAlgorithm.ClassicMcEliece348864);
+        Assert.False(kem.SupportsDerandomizedKeypair);
+        Assert.False(kem.SupportsDerandomizedEncapsulation);
+
+        var (publicKey, _) = kem.GenerateKeypair();
+
+        var keypairEx = Assert.Throws<ArgumentException>(
+            () => kem.GenerateKeypair(Array.Empty<byte>()));
+        Assert.Equal("seed", keypairEx.ParamName);
+
+        var encapsEx = Assert.Throws<ArgumentException>(
+            () => kem.Encapsulate(publicKey, Array.Empty<byte>()));
+        Assert.Equal("seed", encapsEx.ParamName);
+    }
+
+    [Fact]
+    public void DerandomizationSupportFlags_ShouldMatchSeedLengths()
+    {
+        using var mlKem = new KemInstance(KemAlgorithm.MlKem512);
+        Assert.True(mlKem.KeypairSeedLength > 0);
+        Assert.True(mlKem.SupportsDerandomizedKeypair);
+        Assert.True(mlKem.EncapsSeedLength > 0);
+        Assert.True(mlKem.SupportsDerandomizedEncapsulation);
+    }
+
+    // OQS_SIG_supports_ctx_str returns a 1-byte C bool; the default P/Invoke return marshalling is
+    // a 4-byte Win32 BOOL. Cross-check the raw binding against the instance property.
+    [SkippableTheory]
+    [InlineData(SigAlgorithm.MlDsa44)]
+    [InlineData(SigAlgorithm.Falcon512)]
+    public void SupportsContextString_ShouldAgreeWithNativeQuery(SigAlgorithm algorithm)
+    {
+        Skip.If(!algorithm.IsEnabled(), $"Algorithm {algorithm} is not enabled in this build.");
+
+        using var sig = new SigInstance(algorithm);
+        var native = Native.Sig.OQS_SIG_supports_ctx_str(algorithm.GetIdentifier());
+        Assert.Equal(native, sig.SupportsContextString);
+    }
+
+    // liboqs exports OQS_MEM_insecure_free, not OQS_MEM_free; the old declaration always threw
+    // EntryPointNotFoundException.
+    [Fact]
+    public void MemoryHelpers_ShouldResolveTheirEntryPoints()
+    {
+        var ptr = Native.Common.OQS_MEM_malloc((UIntPtr)64);
+        Assert.NotEqual(IntPtr.Zero, ptr);
+
+        Native.Common.OQS_MEM_cleanse(ptr, (UIntPtr)64);
+        Native.Common.OQS_MEM_insecure_free(ptr);
+
+        var secure = Native.Common.OQS_MEM_malloc((UIntPtr)64);
+        Assert.NotEqual(IntPtr.Zero, secure);
+        Native.Common.OQS_MEM_secure_free(secure, (UIntPtr)64);
+    }
+
+    // Initialize() used to run from a static constructor, so a missing or wrong-architecture
+    // native library surfaced as TypeInitializationException and poisoned the type permanently.
+    // It is now an ordinary idempotent method.
+    [Fact]
+    public void Initialize_ShouldBeIdempotentAndRetryable()
+    {
+        LibOqs.Initialize();
+        LibOqs.Initialize();
+        Assert.True(LibOqs.IsInitialized);
+
+        LibOqs.EnsureInitialized();
+        Assert.True(LibOqs.IsInitialized);
+    }
+}

--- a/src/LibOQS.NET.Tests/KemTests.cs
+++ b/src/LibOQS.NET.Tests/KemTests.cs
@@ -271,9 +271,9 @@ public class KemTests
         var (publicKey, secretKey) = kem.GenerateKeypair();
         var (ciphertext, _) = kem.Encapsulate(publicKey);
 
-        Assert.Throws<NullReferenceException>(() => kem.Encapsulate(null!));
-        Assert.Throws<NullReferenceException>(() => kem.Decapsulate(null!, ciphertext));
-        Assert.Throws<NullReferenceException>(() => kem.Decapsulate(secretKey, null!));
+        Assert.Throws<ArgumentNullException>(() => kem.Encapsulate(null!));
+        Assert.Throws<ArgumentNullException>(() => kem.Decapsulate(null!, ciphertext));
+        Assert.Throws<ArgumentNullException>(() => kem.Decapsulate(secretKey, null!));
     }
 
     [Fact]

--- a/src/LibOQS.NET.Tests/SigTests.cs
+++ b/src/LibOQS.NET.Tests/SigTests.cs
@@ -57,7 +57,9 @@ public class SigTests
     [InlineData(SigAlgorithm.Mqom2Cat1Gf16FastR3)]
     [InlineData(SigAlgorithm.Mqom2Cat1Gf16ShortR3)]
     [InlineData(SigAlgorithm.Mqom2Cat3Gf16FastR3)]
+    [InlineData(SigAlgorithm.Mqom2Cat3Gf16ShortR3)]
     [InlineData(SigAlgorithm.Mqom2Cat5Gf16FastR3)]
+    [InlineData(SigAlgorithm.Mqom2Cat5Gf16ShortR5)]
     public void SigSignVerify_ShouldSucceed(SigAlgorithm algorithm)
     {
         Skip.If(!algorithm.IsEnabled(), $"Algorithm {algorithm} is not enabled in this build.");

--- a/src/LibOQS.NET.Tests/SigTests.cs
+++ b/src/LibOQS.NET.Tests/SigTests.cs
@@ -289,8 +289,8 @@ public class SigTests
         var (publicKey, secretKey) = sig.GenerateKeypair();
         var signature = new byte[100];
 
-        Assert.Throws<NullReferenceException>(() => sig.Sign(null!, secretKey));
-        Assert.Throws<NullReferenceException>(() => sig.Verify(null!, signature, publicKey));
+        Assert.Throws<ArgumentNullException>(() => sig.Sign(null!, secretKey));
+        Assert.Throws<ArgumentNullException>(() => sig.Verify(null!, signature, publicKey));
     }
 
     [Fact]
@@ -301,9 +301,9 @@ public class SigTests
         var signature = new byte[100];
         var publicKey = new byte[sig.PublicKeyLength];
 
-        Assert.Throws<NullReferenceException>(() => sig.Sign(message, null!));
-        Assert.Throws<NullReferenceException>(() => sig.Verify(message, signature, null!));
-        Assert.Throws<NullReferenceException>(() => sig.Verify(message, null!, publicKey));
+        Assert.Throws<ArgumentNullException>(() => sig.Sign(message, null!));
+        Assert.Throws<ArgumentNullException>(() => sig.Verify(message, signature, null!));
+        Assert.Throws<ArgumentNullException>(() => sig.Verify(message, null!, publicKey));
     }
 
     [Fact]

--- a/src/LibOQS.NET/Kem.cs
+++ b/src/LibOQS.NET/Kem.cs
@@ -161,9 +161,9 @@ public static class KemAlgorithmExtensions
 /// </summary>
 public class KemInstance : IDisposable
 {
-    private IntPtr _kemPtr;
-    private Kem.OqsKem _kem;
-    private bool _disposed = false;
+    private readonly OqsKemHandle _handle;
+    private readonly Kem.OqsKem _kem;
+    private bool _disposed;
 
     /// <summary>
     /// Algorithm being used
@@ -191,14 +191,26 @@ public class KemInstance : IDisposable
     public int SharedSecretLength => (int)_kem.length_shared_secret;
 
     /// <summary>
-    /// Length of seeds for derandomized keypair generation in bytes
+    /// Length of seeds for derandomized keypair generation in bytes, or 0 if the algorithm does
+    /// not support derandomized keypair generation
     /// </summary>
     public int KeypairSeedLength => (int)_kem.length_keypair_seed;
 
     /// <summary>
-    /// Length of seeds for derandomized encapsulation in bytes
+    /// Length of seeds for derandomized encapsulation in bytes, or 0 if the algorithm does not
+    /// support derandomized encapsulation
     /// </summary>
     public int EncapsSeedLength => (int)_kem.length_encaps_seed;
+
+    /// <summary>
+    /// Whether the algorithm supports derandomized (deterministic) keypair generation
+    /// </summary>
+    public bool SupportsDerandomizedKeypair => KeypairSeedLength > 0;
+
+    /// <summary>
+    /// Whether the algorithm supports derandomized (deterministic) encapsulation
+    /// </summary>
+    public bool SupportsDerandomizedEncapsulation => EncapsSeedLength > 0;
 
     /// <summary>
     /// Create a new KEM instance
@@ -213,13 +225,14 @@ public class KemInstance : IDisposable
             throw new AlgorithmNotSupportedException(algorithm.GetIdentifier());
         }
 
-        _kemPtr = Kem.OQS_KEM_new(algorithm.GetIdentifier());
-        if (_kemPtr == IntPtr.Zero)
+        _handle = Kem.OQS_KEM_new_handle(algorithm.GetIdentifier());
+        if (_handle.IsInvalid)
         {
+            _handle.Dispose();
             throw new OqsException($"Failed to create KEM instance for {algorithm}");
         }
 
-        _kem = Marshal.PtrToStructure<Kem.OqsKem>(_kemPtr);
+        _kem = Marshal.PtrToStructure<Kem.OqsKem>(_handle.DangerousGetHandle());
     }
 
     /// <summary>
@@ -234,15 +247,24 @@ public class KemInstance : IDisposable
     }
 
     /// <summary>
-    /// Generate a new keypair
+    /// Generate a new keypair, optionally derandomized from <paramref name="seed"/>
     /// </summary>
     public (byte[] PublicKey, byte[] SecretKey) GenerateKeypair(byte[]? seed = null)
     {
         ThrowIfDisposed();
 
-        if (seed != null && seed.Length != KeypairSeedLength)
+        if (seed != null)
         {
-            throw new ArgumentException($"Seed must be {KeypairSeedLength} bytes");
+            if (!SupportsDerandomizedKeypair)
+            {
+                throw new ArgumentException(
+                    $"Algorithm {Algorithm} does not support derandomized keypair generation", nameof(seed));
+            }
+
+            if (seed.Length != KeypairSeedLength)
+            {
+                throw new ArgumentException($"Seed must be {KeypairSeedLength} bytes", nameof(seed));
+            }
         }
 
         var publicKey = new byte[PublicKeyLength];
@@ -257,12 +279,12 @@ public class KemInstance : IDisposable
                 {
                     fixed (byte* seedPtr = seed)
                     {
-                        result = Kem.OQS_KEM_keypair_derand(_kemPtr, (IntPtr)pkPtr, (IntPtr)skPtr, (IntPtr)seedPtr);
+                        result = Kem.OQS_KEM_keypair_derand(_handle, (IntPtr)pkPtr, (IntPtr)skPtr, (IntPtr)seedPtr);
                     }
                 }
                 else
                 {
-                    result = Kem.OQS_KEM_keypair(_kemPtr, (IntPtr)pkPtr, (IntPtr)skPtr);
+                    result = Kem.OQS_KEM_keypair(_handle, (IntPtr)pkPtr, (IntPtr)skPtr);
                 }
 
                 if (result != Common.OqsStatus.Success)
@@ -276,20 +298,35 @@ public class KemInstance : IDisposable
     }
 
     /// <summary>
-    /// Encapsulate a shared secret using the public key
+    /// Encapsulate a shared secret using the public key, optionally derandomized from
+    /// <paramref name="seed"/>
     /// </summary>
     public (byte[] Ciphertext, byte[] SharedSecret) Encapsulate(byte[] publicKey, byte[]? seed = null)
     {
         ThrowIfDisposed();
 
-        if (publicKey.Length != PublicKeyLength)
+        if (publicKey == null)
         {
-            throw new ArgumentException($"Public key must be {PublicKeyLength} bytes");
+            throw new ArgumentNullException(nameof(publicKey));
         }
 
-        if (seed != null && seed.Length != EncapsSeedLength)
+        if (publicKey.Length != PublicKeyLength)
         {
-            throw new ArgumentException($"Seed must be {EncapsSeedLength} bytes");
+            throw new ArgumentException($"Public key must be {PublicKeyLength} bytes", nameof(publicKey));
+        }
+
+        if (seed != null)
+        {
+            if (!SupportsDerandomizedEncapsulation)
+            {
+                throw new ArgumentException(
+                    $"Algorithm {Algorithm} does not support derandomized encapsulation", nameof(seed));
+            }
+
+            if (seed.Length != EncapsSeedLength)
+            {
+                throw new ArgumentException($"Seed must be {EncapsSeedLength} bytes", nameof(seed));
+            }
         }
 
         var ciphertext = new byte[CiphertextLength];
@@ -304,12 +341,12 @@ public class KemInstance : IDisposable
                 {
                     fixed (byte* seedPtr = seed)
                     {
-                        result = Kem.OQS_KEM_encaps_derand(_kemPtr, (IntPtr)ctPtr, (IntPtr)ssPtr, (IntPtr)pkPtr, (IntPtr)seedPtr);
+                        result = Kem.OQS_KEM_encaps_derand(_handle, (IntPtr)ctPtr, (IntPtr)ssPtr, (IntPtr)pkPtr, (IntPtr)seedPtr);
                     }
                 }
                 else
                 {
-                    result = Kem.OQS_KEM_encaps(_kemPtr, (IntPtr)ctPtr, (IntPtr)ssPtr, (IntPtr)pkPtr);
+                    result = Kem.OQS_KEM_encaps(_handle, (IntPtr)ctPtr, (IntPtr)ssPtr, (IntPtr)pkPtr);
                 }
 
                 if (result != Common.OqsStatus.Success)
@@ -329,14 +366,24 @@ public class KemInstance : IDisposable
     {
         ThrowIfDisposed();
 
+        if (secretKey == null)
+        {
+            throw new ArgumentNullException(nameof(secretKey));
+        }
+
+        if (ciphertext == null)
+        {
+            throw new ArgumentNullException(nameof(ciphertext));
+        }
+
         if (secretKey.Length != SecretKeyLength)
         {
-            throw new ArgumentException($"Secret key must be {SecretKeyLength} bytes");
+            throw new ArgumentException($"Secret key must be {SecretKeyLength} bytes", nameof(secretKey));
         }
 
         if (ciphertext.Length != CiphertextLength)
         {
-            throw new ArgumentException($"Ciphertext must be {CiphertextLength} bytes");
+            throw new ArgumentException($"Ciphertext must be {CiphertextLength} bytes", nameof(ciphertext));
         }
 
         var sharedSecret = new byte[SharedSecretLength];
@@ -345,7 +392,7 @@ public class KemInstance : IDisposable
         {
             fixed (byte* skPtr = secretKey, ctPtr = ciphertext, ssPtr = sharedSecret)
             {
-                var result = Kem.OQS_KEM_decaps(_kemPtr, (IntPtr)ssPtr, (IntPtr)ctPtr, (IntPtr)skPtr);
+                var result = Kem.OQS_KEM_decaps(_handle, (IntPtr)ssPtr, (IntPtr)ctPtr, (IntPtr)skPtr);
                 if (result != Common.OqsStatus.Success)
                 {
                     throw new OqsException("Failed to decapsulate");
@@ -357,27 +404,13 @@ public class KemInstance : IDisposable
     }
 
     /// <summary>
-    /// Dispose of the KEM instance
+    /// Release the native KEM instance. Idempotent and safe to call from multiple threads.
     /// </summary>
     public void Dispose()
     {
-        if (!_disposed)
-        {
-            if (_kemPtr != IntPtr.Zero)
-            {
-                Kem.OQS_KEM_free(_kemPtr);
-                _kemPtr = IntPtr.Zero;
-            }
-            _disposed = true;
-        }
-        GC.SuppressFinalize(this);
-    }
-
-    /// <summary>
-    /// Finalizer
-    /// </summary>
-    ~KemInstance()
-    {
-        Dispose();
+        _disposed = true;
+        // SafeHandle.Dispose is itself idempotent and thread-safe, and waits for any in-flight
+        // P/Invoke that holds a reference to the handle.
+        _handle.Dispose();
     }
 }

--- a/src/LibOQS.NET/LibOQS.NET.csproj
+++ b/src/LibOQS.NET/LibOQS.NET.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LibOQS.NET</PackageId>
-    <PackageVersion>0.4.0-rc1</PackageVersion>
+    <PackageVersion>0.4.0</PackageVersion>
     <Authors>filipw</Authors>
     <Description>A .NET wrapper for liboqs - a C library for quantum-resistant cryptographic algorithms</Description>
     <PackageProjectUrl>https://github.com/filipw/maybe-liboqs-dotnet</PackageProjectUrl>

--- a/src/LibOQS.NET/LibOqs.cs
+++ b/src/LibOQS.NET/LibOqs.cs
@@ -23,46 +23,54 @@ public class AlgorithmNotSupportedException : OqsException
 /// </summary>
 public static class LibOqs
 {
-    private static bool _initialized = false;
+    private static volatile bool _initialized;
     private static readonly object _initLock = new object();
 
     /// <summary>
-    /// Static constructor to automatically initialize LibOQS when first accessed
-    /// </summary>
-    static LibOqs()
-    {
-        Initialize();
-    }
-
-    /// <summary>
-    /// Initialize the OQS library. This should be called before using any other OQS functions.
+    /// Initialize the OQS library. Calling this is optional: every entry point that needs the
+    /// native library initializes it on demand. Safe to call repeatedly and from multiple threads.
     /// </summary>
     public static void Initialize()
     {
+        if (_initialized)
+        {
+            return;
+        }
+
         lock (_initLock)
         {
-            if (!_initialized)
+            if (_initialized)
             {
-                try
-                {
-                    Native.Common.OQS_init();
-                    _initialized = true;
-                }
-                catch (DllNotFoundException ex)
-                {
-                    throw new OqsException(
-                        "Unable to load the liboqs shared library. " +
-                        "Please ensure that oqs.dll (Windows), liboqs.so (Linux), or liboqs.dylib (macOS) " +
-                        "is available in your system's library path or in the application directory. " +
-                        "See BUILD.md for installation instructions.", ex);
-                }
+                return;
             }
+
+            try
+            {
+                Native.Common.OQS_init();
+            }
+            catch (Exception ex) when (ex is DllNotFoundException
+                                    || ex is BadImageFormatException
+                                    || ex is EntryPointNotFoundException)
+            {
+                throw new OqsException(
+                    "Unable to load the liboqs native library. Ensure that oqs.dll (Windows), " +
+                    "liboqs.so (Linux) or liboqs.dylib (macOS) built for this process architecture " +
+                    "is present in the application directory or on the platform's library search " +
+                    "path. See the \"Building from Source\" section of README.md.", ex);
+            }
+
+            _initialized = true;
         }
     }
 
     /// <summary>
-    /// Cleanup the OQS library
+    /// Cleanup the OQS library.
     /// </summary>
+    /// <remarks>
+    /// Only call this once every <see cref="KemInstance"/> and <see cref="SigInstance"/> has been
+    /// disposed; liboqs behaviour is undefined if instances outlive <c>OQS_destroy</c>. This is not
+    /// invoked automatically at process exit.
+    /// </remarks>
     public static void Cleanup()
     {
         lock (_initLock)
@@ -83,11 +91,5 @@ public static class LibOqs
     /// <summary>
     /// Ensure the library is initialized, automatically initializing if needed
     /// </summary>
-    public static void EnsureInitialized()
-    {
-        if (!_initialized)
-        {
-            Initialize();
-        }
-    }
+    public static void EnsureInitialized() => Initialize();
 }

--- a/src/LibOQS.NET/Sig.cs
+++ b/src/LibOQS.NET/Sig.cs
@@ -269,9 +269,9 @@ public static class SigAlgorithmExtensions
 /// </summary>
 public class SigInstance : IDisposable
 {
-    private IntPtr _sigPtr;
-    private Sig.OqsSig _sig;
-    private bool _disposed = false;
+    private readonly OqsSigHandle _handle;
+    private readonly Sig.OqsSig _sig;
+    private bool _disposed;
 
     /// <summary>
     /// Algorithm being used
@@ -296,7 +296,7 @@ public class SigInstance : IDisposable
     /// <summary>
     /// Whether the algorithm supports context strings
     /// </summary>
-    public bool SupportsContextString => Sig.OQS_SIG_supports_ctx_str(Algorithm.GetIdentifier());
+    public bool SupportsContextString => _sig.sig_with_ctx_support != 0;
 
     /// <summary>
     /// Create a new signature instance
@@ -311,13 +311,14 @@ public class SigInstance : IDisposable
             throw new AlgorithmNotSupportedException(algorithm.GetIdentifier());
         }
 
-        _sigPtr = Sig.OQS_SIG_new(algorithm.GetIdentifier());
-        if (_sigPtr == IntPtr.Zero)
+        _handle = Sig.OQS_SIG_new_handle(algorithm.GetIdentifier());
+        if (_handle.IsInvalid)
         {
+            _handle.Dispose();
             throw new OqsException($"Failed to create signature instance for {algorithm}");
         }
 
-        _sig = Marshal.PtrToStructure<Sig.OqsSig>(_sigPtr);
+        _sig = Marshal.PtrToStructure<Sig.OqsSig>(_handle.DangerousGetHandle());
     }
 
     /// <summary>
@@ -345,7 +346,7 @@ public class SigInstance : IDisposable
         {
             fixed (byte* pkPtr = publicKey, skPtr = secretKey)
             {
-                var result = Sig.OQS_SIG_keypair(_sigPtr, (IntPtr)pkPtr, (IntPtr)skPtr);
+                var result = Sig.OQS_SIG_keypair(_handle, (IntPtr)pkPtr, (IntPtr)skPtr);
                 if (result != Common.OqsStatus.Success)
                 {
                     throw new OqsException("Failed to generate keypair");
@@ -357,20 +358,30 @@ public class SigInstance : IDisposable
     }
 
     /// <summary>
-    /// Sign a message
+    /// Sign a message, optionally with a context string
     /// </summary>
     public byte[] Sign(byte[] message, byte[] secretKey, byte[]? ctxStr = null)
     {
         ThrowIfDisposed();
 
+        if (message == null)
+        {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        if (secretKey == null)
+        {
+            throw new ArgumentNullException(nameof(secretKey));
+        }
+
         if (secretKey.Length != SecretKeyLength)
         {
-            throw new ArgumentException($"Secret key must be {SecretKeyLength} bytes");
+            throw new ArgumentException($"Secret key must be {SecretKeyLength} bytes", nameof(secretKey));
         }
 
         if (ctxStr != null && !SupportsContextString)
         {
-            throw new ArgumentException($"Algorithm {Algorithm} does not support context strings");
+            throw new ArgumentException($"Algorithm {Algorithm} does not support context strings", nameof(ctxStr));
         }
 
         var signature = new byte[MaxSignatureLength];
@@ -385,13 +396,13 @@ public class SigInstance : IDisposable
                 {
                     fixed (byte* ctxPtr = ctxStr)
                     {
-                        result = Sig.OQS_SIG_sign_with_ctx_str(_sigPtr, (IntPtr)sigPtr, ref signatureLength,
+                        result = Sig.OQS_SIG_sign_with_ctx_str(_handle, (IntPtr)sigPtr, ref signatureLength,
                             (IntPtr)msgPtr, (UIntPtr)message.Length, (IntPtr)ctxPtr, (UIntPtr)ctxStr.Length, (IntPtr)skPtr);
                     }
                 }
                 else
                 {
-                    result = Sig.OQS_SIG_sign(_sigPtr, (IntPtr)sigPtr, ref signatureLength,
+                    result = Sig.OQS_SIG_sign(_handle, (IntPtr)sigPtr, ref signatureLength,
                         (IntPtr)msgPtr, (UIntPtr)message.Length, (IntPtr)skPtr);
                 }
 
@@ -402,27 +413,51 @@ public class SigInstance : IDisposable
             }
         }
 
-        // Return only the actual signature length
-        var actualSignature = new byte[(int)signatureLength];
-        Array.Copy(signature, actualSignature, (int)signatureLength);
+        // Signature lengths are variable for some algorithms (e.g. Falcon), so trim the buffer
+        // down to what liboqs actually wrote.
+        if (signatureLength.ToUInt64() > (ulong)MaxSignatureLength)
+        {
+            throw new OqsException(
+                $"liboqs reported a signature length of {signatureLength} bytes, which exceeds the " +
+                $"maximum of {MaxSignatureLength} bytes for {Algorithm}");
+        }
+
+        var actualLength = (int)signatureLength;
+        var actualSignature = new byte[actualLength];
+        Array.Copy(signature, actualSignature, actualLength);
         return actualSignature;
     }
 
     /// <summary>
-    /// Verify a signature
+    /// Verify a signature, optionally with a context string
     /// </summary>
     public bool Verify(byte[] message, byte[] signature, byte[] publicKey, byte[]? ctxStr = null)
     {
         ThrowIfDisposed();
 
+        if (message == null)
+        {
+            throw new ArgumentNullException(nameof(message));
+        }
+
+        if (signature == null)
+        {
+            throw new ArgumentNullException(nameof(signature));
+        }
+
+        if (publicKey == null)
+        {
+            throw new ArgumentNullException(nameof(publicKey));
+        }
+
         if (publicKey.Length != PublicKeyLength)
         {
-            throw new ArgumentException($"Public key must be {PublicKeyLength} bytes");
+            throw new ArgumentException($"Public key must be {PublicKeyLength} bytes", nameof(publicKey));
         }
 
         if (ctxStr != null && !SupportsContextString)
         {
-            throw new ArgumentException($"Algorithm {Algorithm} does not support context strings");
+            throw new ArgumentException($"Algorithm {Algorithm} does not support context strings", nameof(ctxStr));
         }
 
         unsafe
@@ -434,42 +469,29 @@ public class SigInstance : IDisposable
                 {
                     fixed (byte* ctxPtr = ctxStr)
                     {
-                        result = Sig.OQS_SIG_verify_with_ctx_str(_sigPtr, (IntPtr)msgPtr, (UIntPtr)message.Length,
+                        result = Sig.OQS_SIG_verify_with_ctx_str(_handle, (IntPtr)msgPtr, (UIntPtr)message.Length,
                             (IntPtr)sigPtr, (UIntPtr)signature.Length, (IntPtr)ctxPtr, (UIntPtr)ctxStr.Length, (IntPtr)pkPtr);
                     }
                 }
                 else
                 {
-                    result = Sig.OQS_SIG_verify(_sigPtr, (IntPtr)msgPtr, (UIntPtr)message.Length,
+                    result = Sig.OQS_SIG_verify(_handle, (IntPtr)msgPtr, (UIntPtr)message.Length,
                         (IntPtr)sigPtr, (UIntPtr)signature.Length, (IntPtr)pkPtr);
                 }
+
                 return result == Common.OqsStatus.Success;
             }
         }
     }
 
     /// <summary>
-    /// Dispose of the signature instance
+    /// Release the native signature instance. Idempotent and safe to call from multiple threads.
     /// </summary>
     public void Dispose()
     {
-        if (!_disposed)
-        {
-            if (_sigPtr != IntPtr.Zero)
-            {
-                Sig.OQS_SIG_free(_sigPtr);
-                _sigPtr = IntPtr.Zero;
-            }
-            _disposed = true;
-        }
-        GC.SuppressFinalize(this);
-    }
-
-    /// <summary>
-    /// Finalizer
-    /// </summary>
-    ~SigInstance()
-    {
-        Dispose();
+        _disposed = true;
+        // SafeHandle.Dispose is itself idempotent and thread-safe, and waits for any in-flight
+        // P/Invoke that holds a reference to the handle.
+        _handle.Dispose();
     }
 }

--- a/website/algorithms.html
+++ b/website/algorithms.html
@@ -70,7 +70,7 @@
           claimed for each.
         </p>
         <div class="masthead__meta">
-          <span><strong>Source</strong> liboqs 0.16.0-rc1</span>
+          <span><strong>Source</strong> liboqs 0.16.0</span>
           <span><a href="index.html">Return to the overview</a></span>
         </div>
       </div>
@@ -286,7 +286,7 @@
           </table>
         </div>
         <div class="note">
-          The pure SLH-DSA variants are disabled on Windows in the bundled liboqs 0.16.0-rc1
+          The pure SLH-DSA variants are disabled on Windows in the bundled liboqs 0.16.0
           release, as noted on the overview page. They are available on Linux and macOS.
         </div>
       </section>
@@ -357,8 +357,9 @@
         <p>
           SNOVA is exposed across twelve parameter sets spanning the three security levels. MQOM
           is exposed across twelve parameter sets, in GF(16) fast and short trade-offs at each
-          level. As noted on the overview page, the MQOM family is disabled on Windows in the
-          bundled release and is available on Linux and macOS.
+          level, and is available on every supported platform. As noted on the overview page, the
+          Windows and macOS builds use the memory-optimised MQOM implementation added in liboqs
+          0.16.0.
         </p>
         <div class="table-wrap">
           <table>

--- a/website/index.html
+++ b/website/index.html
@@ -73,7 +73,7 @@
           native library bundled so that no separate compilation step is required.
         </p>
         <div class="masthead__meta">
-          <span><strong>Wraps</strong> liboqs 0.16.0-rc1</span>
+          <span><strong>Wraps</strong> liboqs 0.16.0</span>
           <span><strong>Runtime</strong> .NET 9.0 or later</span>
           <span><strong>Licence</strong> MIT</span>
           <span><strong>Platforms</strong> Windows, Linux, macOS</span>
@@ -598,10 +598,17 @@ Console.WriteLine($"Secrets equal: {bobSecret.SequenceEqual(aliceSecret)}");</co
           <li>macOS ARM64</li>
         </ul>
         <div class="note">
-          <strong>Known limitations on Windows.</strong> With liboqs 0.16.0-rc1, the pure
-          SLH-DSA variants and the MQOM family are disabled on Windows because a defect in that
-          release causes a stack overflow during signing. BIKE is also disabled on Windows. These
-          algorithms remain available on the other supported platforms.
+          <strong>Known limitations on Windows.</strong> The pure SLH-DSA variants are disabled on
+          Windows because a defect in liboqs causes a stack overflow during signing. BIKE is
+          unavailable because liboqs itself does not support it on Windows. Both remain available
+          on the other supported platforms.
+        </div>
+        <div class="note">
+          <strong>MQOM.</strong> The MQOM family is available on every supported platform. On
+          Windows and macOS it is built from the memory-optimised implementation introduced in
+          liboqs 0.16.0, because the default implementation requires more than 1 MB of stack to
+          sign and so overflows the stack of non-main threads. On Linux the default implementation
+          is used, which is AVX2-accelerated on x64.
         </div>
       </section>
 

--- a/website/index.html
+++ b/website/index.html
@@ -623,11 +623,21 @@ Console.WriteLine($"Secrets equal: {bobSecret.SequenceEqual(aliceSecret)}");</co
         </p>
         <p>
           Initialisation happens automatically the first time the library is used, and that path
-          is safe to call from multiple threads. For the algorithm instances themselves, the
-          recommendation is to use a separate instance per thread rather than sharing one. An
-          optional <code>LibOqs.Cleanup()</code> call is available for releasing library-wide
-          resources once at application shutdown.
+          is safe to call from multiple threads. Disposal is idempotent and may be called
+          concurrently; an instance that is never disposed is still released by the handle's
+          critical finaliser. For the algorithm instances themselves, the recommendation is to use
+          a separate instance per thread rather than sharing one. An optional
+          <code>LibOqs.Cleanup()</code> call is available for releasing library-wide resources, and
+          should be made only after every instance has been disposed. It is not invoked
+          automatically at process exit.
         </p>
+        <div class="note">
+          <strong>Key material is not erased for you.</strong> Keys and shared secrets are returned
+          as ordinary managed <code>byte[]</code>. The garbage collector may move or copy those
+          arrays and nothing zeroes them once they fall out of scope, so the library cannot
+          guarantee secrets are cleared from process memory. Where that matters, clear the arrays
+          yourself once finished with them.
+        </div>
       </section>
 
       <section id="acknowledgements">


### PR DESCRIPTION
Correctness pass over the P/Invoke layer and the managed wrappers.

- `KemInstance`/`SigInstance` now hold a `SafeHandle` instead of a raw `IntPtr`. The old
  unsynchronised `Dispose()` could free the same `OQS_KEM`/`OQS_SIG` twice and abort the process.
- Fixed `Common.OQS_MEM_free`, which never resolved - liboqs exports `OQS_MEM_insecure_free`
  Old name kept as an `[Obsolete]`
- Moved `LibOqs.Initialize()` out of the static constructor, so a missing or wrong-architecture
  native library is reported properly instead of poisoning the type
- Explicitly marshal the 1-byte C `bool` returned by `OQS_SIG_supports_ctx_str`
- Reject zero-length derandomisation seeds, which previously slipped past the length check
- Throw `ArgumentNullException` rather than `NullReferenceException` on null arguments
- Updated README/website

Three existing tests asserted `NullReferenceException` for null arguments, so they
changed too.

Secrets still live in unzeroed managed `byte[]`, fixing that needs a `Span`-based API and belongs
in its own PR.