### PR TITLE
Musl fixes for MQOM

### DIFF
--- a/build-dotnet-liboqs-linux.sh
+++ b/build-dotnet-liboqs-linux.sh
@@ -37,6 +37,16 @@ CMAKE_ARGS="$CMAKE_ARGS -DOQS_USE_OPENSSL=OFF"
 CMAKE_ARGS="$CMAKE_ARGS -DOQS_BUILD_ONLY_LIB=ON"
 CMAKE_ARGS="$CMAKE_ARGS -DOQS_DIST_BUILD=YES"
 CMAKE_ARGS="$CMAKE_ARGS -DOQS_PERMIT_UNSUPPORTED_ARCHITECTURE=ON"
+
+# On musl (Alpine), .NET gives non-main threads about 1.5 MB, versus about 8 MB on glibc where
+# the ulimit is inherited. That is not enough for the default MQOM implementation, whose "short"
+# parameter sets need more than 1 MB to sign. Build the memory-optimized implementation there,
+# for the same reason the Windows and macOS builds do. glibc keeps the default (AVX2-accelerated
+# on x64) implementation, which is faster and fits comfortably in its larger stacks.
+if (ldd --version 2>&1 | grep -qi musl) || [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ]; then
+    echo "musl libc detected: enabling OQS_MEMOPT_BUILD"
+    CMAKE_ARGS="$CMAKE_ARGS -DOQS_MEMOPT_BUILD=ON"
+fi
 CMAKE_ARGS="$CMAKE_ARGS -DOQS_ENABLE_KEM_ML_KEM=ON"
 CMAKE_ARGS="$CMAKE_ARGS -DOQS_ENABLE_KEM_KYBER=ON"
 CMAKE_ARGS="$CMAKE_ARGS -DOQS_ENABLE_KEM_FRODOKEM=ON"

--- a/src/LibOQS.NET.Native/LibOQS.NET.Native.csproj
+++ b/src/LibOQS.NET.Native/LibOQS.NET.Native.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LibOQS.NET.Native</PackageId>
-    <PackageVersion>0.4.0</PackageVersion>
+    <PackageVersion>0.4.1</PackageVersion>
     <Authors>filipw</Authors>
     <Description>Native P/Invoke bindings for liboqs - a C library for quantum-resistant cryptographic algorithms</Description>
     <PackageProjectUrl>https://github.com/filipw/maybe-liboqs-dotnet</PackageProjectUrl>

--- a/src/LibOQS.NET.Tests/DefaultStackTests.cs
+++ b/src/LibOQS.NET.Tests/DefaultStackTests.cs
@@ -1,0 +1,109 @@
+using LibOQS.NET;
+using Xunit;
+
+namespace LibOQS.NET.Tests;
+
+/// <summary>
+/// Algorithms that must work on an ordinary thread, with no help from <see cref="LargeStack"/>.
+/// </summary>
+/// <remarks>
+/// Every other algorithm test runs inside a generously sized thread so it measures the algorithm
+/// rather than the ambient stack. That is deliberate, but it means those tests cannot detect a
+/// platform whose default thread stack is too small - and the platforms differ a lot. .NET gives
+/// non-main threads roughly 1.5 MB on musl (Alpine) against roughly 8 MB on glibc.
+///
+/// These tests deliberately run on a plain thread pool thread, the same place an ASP.NET request
+/// handler or a Task.Run callback executes, so that a platform which cannot host the common
+/// algorithms fails here rather than in a consumer's container. Keep this list to parameter sets
+/// that fit comfortably everywhere; genuinely heavy ones are documented as needing a caller-sized
+/// thread and belong in the LargeStack-wrapped tests instead.
+///
+/// A stack overflow is fail-fast, so a regression here crashes the test host rather than failing
+/// an assertion. That is louder than it is pretty, and it is the point.
+/// </remarks>
+public class DefaultStackTests
+{
+    private static void OnThreadPoolThread(Action body)
+    {
+        Exception? failure = null;
+        using var done = new ManualResetEventSlim(false);
+
+        ThreadPool.QueueUserWorkItem(_ =>
+        {
+            try
+            {
+                body();
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+            finally
+            {
+                done.Set();
+            }
+        });
+
+        Assert.True(done.Wait(TimeSpan.FromMinutes(2)), "Operation did not complete");
+        if (failure != null)
+        {
+            throw failure;
+        }
+    }
+
+    [SkippableTheory]
+    [InlineData(SigAlgorithm.MlDsa44)]
+    [InlineData(SigAlgorithm.MlDsa65)]
+    [InlineData(SigAlgorithm.MlDsa87)]
+    [InlineData(SigAlgorithm.Falcon512)]
+    [InlineData(SigAlgorithm.Falcon1024)]
+    [InlineData(SigAlgorithm.Mayo1)]
+    [InlineData(SigAlgorithm.Mayo2)]
+    [InlineData(SigAlgorithm.CrossRsdp128Balanced)]
+    [InlineData(SigAlgorithm.CrossRsdpg128Balanced)]
+    [InlineData(SigAlgorithm.UovOvIs)]
+    [InlineData(SigAlgorithm.Snova24_5_4)]
+    [InlineData(SigAlgorithm.Mqom2Cat1Gf16FastR3)]
+    // The MQOM "short" sets need the memory-optimized build to fit here. They regressed on musl
+    // because only the Windows and macOS builds passed OQS_MEMOPT_BUILD.
+    [InlineData(SigAlgorithm.Mqom2Cat1Gf16ShortR3)]
+    [InlineData(SigAlgorithm.Mqom2Cat3Gf16ShortR3)]
+    [InlineData(SigAlgorithm.Mqom2Cat5Gf16ShortR5)]
+    public void Sig_ShouldWorkOnADefaultThread(SigAlgorithm algorithm)
+    {
+        Skip.If(!algorithm.IsEnabled(), $"Algorithm {algorithm} is not enabled in this build.");
+
+        OnThreadPoolThread(() =>
+        {
+            using var sig = new SigInstance(algorithm);
+            var (publicKey, secretKey) = sig.GenerateKeypair();
+            var message = "default stack probe"u8.ToArray();
+            var signature = sig.Sign(message, secretKey);
+            Assert.True(sig.Verify(message, signature, publicKey));
+        });
+    }
+
+    [SkippableTheory]
+    [InlineData(KemAlgorithm.MlKem512)]
+    [InlineData(KemAlgorithm.MlKem768)]
+    [InlineData(KemAlgorithm.MlKem1024)]
+    [InlineData(KemAlgorithm.Kyber512)]
+    [InlineData(KemAlgorithm.Hqc1)]
+    [InlineData(KemAlgorithm.FrodoKem640Aes)]
+    [InlineData(KemAlgorithm.EFrodoKem640Aes)]
+    [InlineData(KemAlgorithm.NtruHps2048509)]
+    [InlineData(KemAlgorithm.NtruPrimeSntrup761)]
+    [InlineData(KemAlgorithm.ClassicMcEliece348864)]
+    public void Kem_ShouldWorkOnADefaultThread(KemAlgorithm algorithm)
+    {
+        Skip.If(!algorithm.IsEnabled(), $"Algorithm {algorithm} is not enabled in this build.");
+
+        OnThreadPoolThread(() =>
+        {
+            using var kem = new KemInstance(algorithm);
+            var (publicKey, secretKey) = kem.GenerateKeypair();
+            var (ciphertext, sharedSecret) = kem.Encapsulate(publicKey);
+            Assert.Equal(sharedSecret, kem.Decapsulate(secretKey, ciphertext));
+        });
+    }
+}

--- a/src/LibOQS.NET/LibOQS.NET.csproj
+++ b/src/LibOQS.NET/LibOQS.NET.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>LibOQS.NET</PackageId>
-    <PackageVersion>0.4.0</PackageVersion>
+    <PackageVersion>0.4.1</PackageVersion>
     <Authors>filipw</Authors>
     <Description>A .NET wrapper for liboqs - a C library for quantum-resistant cryptographic algorithms</Description>
     <PackageProjectUrl>https://github.com/filipw/maybe-liboqs-dotnet</PackageProjectUrl>


### PR DESCRIPTION
liboqs ships a memory-optimized implementation of MQOM that needs far less stack. 

Our Windows and macOS builds enabled it but our Linux build didn't, because glibc's 8 MB made it unnecessary there. 
That reasoning doesn't hold for musl. All six MQOM `short` parameter sets overflow on Alpine without it and fit comfortably with it - verified on both Alpine x64 and arm64. 

The Linux build now enables it automatically when it detects musl.